### PR TITLE
Add method to create sample type indepent of creating an operation type

### DIFF
--- a/pydent/interfaces.py
+++ b/pydent/interfaces.py
@@ -264,6 +264,13 @@ class UtilityInterface(CRUDInterface):
         library.reload(result)
         return library
 
+    def create_sample_type(self, sample_type):
+        """Create a Sample Type independent of an Operation Type"""
+        st_data = sample_type.dump(include=("field_types"))
+        result = self.aqhttp.post('sample_types.json', json_data=st_data)
+        sample_type.reload(result)
+        return sample_type
+
     def create_upload(self, upload):
         files = {"file": upload.file}
         result = self.aqhttp.post(


### PR DESCRIPTION
Currently, pydent will create sample types if they are attached as AFTs to an input or output for an Operation Type. However, this process does not create field types that are part of the sample types (i.e. Field Types that have Sample Type as their parent class). This adds a separate method for creating these types. 